### PR TITLE
Update to bash 5.1.8, fix keyserver

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,9 +26,9 @@ pushd build
 echo "= preparing gpg"
 export GNUPGHOME="$(mktemp -d)"
 # public key for bash
-gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB
+gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 7C0135FB088AAF6C66C650B9BB5869F064EA74AB
 # public key for musl
-gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 836489290BB6B70F99FFDA0556BCDB593020450F
+gpg --batch --keyserver hkp://keyserver.ubuntu.com --recv-keys 836489290BB6B70F99FFDA0556BCDB593020450F
 
 # download tarballs
 echo "= downloading bash"

--- a/version.sh
+++ b/version.sh
@@ -1,3 +1,3 @@
 bash_version="5.1"
-bash_patch_level=4
+bash_patch_level=8
 musl_version="1.2.2"


### PR DESCRIPTION
I have tested these changes on my local machine, and it is working.

- Update for Bash 5.1.8.
- Switch to keyserver.ubuntu.com (the previous keyserver did not connect for me).