### PR TITLE
Use c89 and disable some lint warnings as errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -101,6 +101,8 @@ else
   if [ "$platform" = "Darwin" ]; then
     # set minimum version of macOS to 10.13
     export MACOSX_DEPLOYMENT_TARGET="10.13"
+    # https://www.gnu.org/software/bash/manual/html_node/Compilers-and-Options.html
+    export CC="gcc -std=c89 -Wno-implicit-function-declaration -Wno-return-type"
   fi
 fi
 


### PR DESCRIPTION
Fixes #17 

On MacOS, add the options `-std=c89 -Wno-implicit-function-declaration -Wno-return-type` or versions of bash less than 5 fail to compile.

For some reason the `CFLAGS` var isn't being respected so I had to add the options to `CC`

Tested on bash 3.2.57 and 4.4.18 and 5.1.8
MacOS 11.5.1