### PR TITLE
Refactored and added multi-version support

### DIFF
--- a/version-20.sh
+++ b/version-20.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+bash_version="2.05b"
+bash_patch_level=13
+musl_version="1.2.5"
+CFLAGS="-std=c89 -Wno-error=implicit-function-declaration -Wno-error=implicit-int"
+NO_SIGS=1
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS
+export NO_SIGS

--- a/version-30.sh
+++ b/version-30.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="3.0"
+bash_patch_level=22
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-31.sh
+++ b/version-31.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="3.1"
+bash_patch_level=23
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=return-mismatch"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-32.sh
+++ b/version-32.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="3.2"
+bash_patch_level=57
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=return-mismatch"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-40.sh
+++ b/version-40.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="4.0"
+bash_patch_level=44
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-41.sh
+++ b/version-41.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="4.1"
+bash_patch_level=17
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-42.sh
+++ b/version-42.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="4.2"
+bash_patch_level=53
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-43.sh
+++ b/version-43.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="4.3"
+bash_patch_level=48
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=implicit-int -Wno-error=incompatible-pointer-types"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-44.sh
+++ b/version-44.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="4.4"
+bash_patch_level=23
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-50.sh
+++ b/version-50.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="5.0"
+bash_patch_level=18
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-51.sh
+++ b/version-51.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="5.1"
+bash_patch_level=16
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version-52.sh
+++ b/version-52.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+bash_version="5.2"
+bash_patch_level=37
+musl_version="1.2.5"
+CFLAGS="-Wno-error=implicit-function-declaration"
+
+export bash_version
+export bash_patch_level
+export musl_version
+export CFLAGS

--- a/version.sh
+++ b/version.sh
@@ -1,9 +1,1 @@
-#!/bin/bash
-
-bash_version="5.2"
-bash_patch_level=15
-musl_version="1.2.3"
-
-export bash_version
-export bash_patch_level
-export musl_version
+version-52.sh


### PR DESCRIPTION
I recently had a need to test some scripts against every bash version and this repo had just the thing I needed. 

I extended the script to allow specifying a bash version to build and included `version-##.sh` files for each, which also handle the compile warnings. Leaving the version off will default to the latest (via symlink).

Also refactored and fixed lint, and made things generally quieter.

Fixes: #42, #45