### PR TITLE
build.sh: show curl errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -37,7 +37,7 @@ mycurl() {
   (($# == 2)) || return
   [[ -f ${1##*/} ]] || { echo "File: ${1##*/} | Url: ${1}" && curl -sLO "$1"; }
   [[ -f ${1##*/}.${2} || ${NO_SIGS:-} ]] || {
-    echo "File: ${1##*/}.${2} | Url: ${1}.${2}" && curl -sLO "${1}.${2}"
+    echo "File: ${1##*/}.${2} | Url: ${1}.${2}" && curl -sSfLO "${1}.${2}"
     gpg --trust-model always --verify "${1##*/}.${2}" "${1##*/}" 2>/dev/null
   }
 }


### PR DESCRIPTION
`-sSf` or `--silent --show-error --fail` is a typical combination of curl cmdline flags to show useful output in CI and also have useful exit status.

In my case, no root cause for the HTTP request failing was shown in the output of build.sh. Through addition of `-S` I got to see:
```
curl: (7) Failed to connect to ftp.gnu.org port 443 after 89 ms: Couldn't connect to server
```

By the adding `-v` I narrowed this down further. The `-S` should be good for everyone though.